### PR TITLE
Change the way we obtain a player's name.

### DIFF
--- a/OmniPause.py
+++ b/OmniPause.py
@@ -28,12 +28,19 @@ bus       = dbus.SessionBus()
 def do_nothing(*args, **kwargs):
     pass
 
+def get_player_name(i, player):
+	if i.startswith("org.mpris.MediaPlayer2."):
+		return i[len("org.mpris.MediaPlayer2."):]
+	else:
+		return player.Get('org.mpris.MediaPlayer2','DesktopEntry', dbus_interface='org.freedesktop.DBus.Properties')
+
+
 def pause():
 	for i in players:
 		player = bus.get_object(i, '/org/mpris/MediaPlayer2')
 		player_status = player.Get('org.mpris.MediaPlayer2.Player','PlaybackStatus', dbus_interface='org.freedesktop.DBus.Properties')
 		if player_status == 'Playing':
-			player_name = player.Get('org.mpris.MediaPlayer2','DesktopEntry', dbus_interface='org.freedesktop.DBus.Properties')
+			player_name = get_player_name(i, player)
 			player_status_file = open(directory+'/paused-players/'+player_name, "w")
 			player_status_file.close()
 			player.Pause(dbus_interface='org.mpris.MediaPlayer2.Player', reply_handler=do_nothing, error_handler=do_nothing)
@@ -62,7 +69,6 @@ def toggle():
 	playing = False
 	for i in players:
 		player = bus.get_object(i, '/org/mpris/MediaPlayer2')
-		player_name = player.Get('org.mpris.MediaPlayer2','DesktopEntry', dbus_interface='org.freedesktop.DBus.Properties')
 		player_status = player.Get('org.mpris.MediaPlayer2.Player','PlaybackStatus', dbus_interface='org.freedesktop.DBus.Properties')
 		if player_status == 'Playing':
 			playing = True


### PR DESCRIPTION
Using the player.Get callback can cause some problems with players such as mps-youtube which don't report a name equal to their own id.

With mps-youtube, the id is of the form `mps-youtube.instanceNNNNN`, but the name reported is `mps-youtube`. Thus, omnipause fails to unpause those players, because it saves the name `mps-youtube` instead of the more complete name.

This commit changes things by obtaining the name from the id, if possible.