### PR TITLE
Added python3 support

### DIFF
--- a/OmniPause.py
+++ b/OmniPause.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -109,7 +109,7 @@ if not os.path.isdir(directory):
 		os.makedirs(directory+'/paused-players')
 	
 
-if len(sys.argv)-1 is 1:
+if len(sys.argv)-1 == 1:
 	getPlayerList()
 	if sys.argv[1] == 'pause':
 		pause()

--- a/OmniPause.py
+++ b/OmniPause.py
@@ -124,6 +124,6 @@ if len(sys.argv)-1 == 1:
 	elif sys.argv[1] == 'toggle':
 		toggle()
 	else:
-		print >> sys.stderr, "Error:  Valid commands to "+sys.argv[0]+"are: pause, play, stop, next, previous, or toggle"
+		print("Error:  Valid commands to "+sys.argv[0]+"are: pause, play, stop, next, previous, or toggle")
 else:
-	print >> sys.stderr, "Usage:  "+sys.argv[0]+" [pause|play|stop|next|previous|toggle]"
+	print("Usage:  "+sys.argv[0]+" [pause|play|stop|next|previous|toggle]")

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Have you ever wished you could control the playback of all your running media pl
 Until now, there was no real good way to do this without spending all of your free time scripting playerctl.  Now, with OmniPause, you can use a single, universal command to control all of your media players, with absolutely zero scripting required!  
 
 ## Dependencies
- * python2
+ * python3
  * dbus-python
 
 ## Setup


### PR DESCRIPTION
All that was needed for python 3 support was a change on the first line, and a change from `is` to `==` around line 112 in the main file. Tested with openSUSE tumbleweed, kernel 5.15.7-1-default